### PR TITLE
Allow developers to preventDefault when its needed

### DIFF
--- a/jquery.pep.js
+++ b/jquery.pep.js
@@ -80,7 +80,6 @@
 
       // Non-touch device -- or -- non-pinch on touch device?
       if ( !this._isTouch() || ( this._isTouch() && event.originalEvent.hasOwnProperty('touches') && event.originalEvent.touches.length == 1 ) ){
-        event.preventDefault();
         var self              = this;
         var $this             = $(this.el);
         $this.addClass( this.options.activeClass );


### PR DESCRIPTION
I recently used your script to create a draggable breadcrumb. For desktop clients I needed to prevent the links from being clicked while the the drag event was active but for mobile clients the line I later removed prevented them all together regardless of the draggable areas state.

Its easier to prevent obvious behavior than it is to speculate about the discrepancies between mobile and desktop. 
