### PR TITLE
Adding support for arbitrary constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,9 @@ defaults = {
     // override pep's default overlap function; takes two args: a & b and returns true if they overlap
     overlapFunction:        false,                                        
     
-    // constrain object to 'window' || 'parent' || 'custom'; works best w/ useCSSTranslation set to false
+    // constrain object to 'window' || 'parent' || [top, right, bottom, left]; works best w/ useCSSTranslation set to false
     constrainTo:            false,                                        
 
-    // constrain object to an arbitrary lower X limit (int)
-    constrainMinX:          false,
-
-    // constrain object to an arbitrary upper X limit (int)
-    constrainMaxX:          false,
-
-    // constrain object to an arbitrary lower Y limit (int)
-    constrainMaxY:          false,
-    
-    // constrain object to an arbitrary upper Y limit (int)
-    constrainMinY:          false,
-    
     // remove margins for better object placement
     removeMargins:          true,                                         
     

--- a/demos/custom-constraint.html
+++ b/demos/custom-constraint.html
@@ -17,17 +17,13 @@
           $('.pep-horizontal').pep({
             axis: 'x',
             useCSSTranslation: false,
-            constrainTo: 'custom',
-            constrainMinX: ($('.pep-horizontal').width() - $('.pep-container-horizontal').width()) * -1,
-            constrainMaxX: 0
+            constrainTo: [0, 0, 0, ($('.pep-horizontal').width() - $('.pep-container-horizontal').width()) * -1]
           });
 
           $('.pep-vertical').pep({
             axis: 'y',
             useCSSTranslation: false,
-            constrainTo: 'custom',
-            constrainMinY: ($('.pep-vertical').height() - $('.pep-container-vertical').height()) * -1,
-            constrainMaxY: 0
+            constrainTo: [($('.pep-vertical').height() - $('.pep-container-vertical').height()) * -1, 0, 0, 0]
           });
 
       });

--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -42,10 +42,6 @@
     droppableActiveClass:   'pep-dpa',                                    // class to add to active droppable parents, default to pep-dpa (droppable parent active)
     overlapFunction:        false,                                        // override pep's default overlap function; takes two args: a & b and returns true if they overlap
     constrainTo:            false,                                        // constrain object to 'window' || 'parent'; works best w/ useCSSTranslation set to false
-    constrainMinX:          false,                                        // constrain object to an arbitrary lower X limit (int)
-    constrainMaxX:          false,                                        // constrain object to an arbitrary upper X limit (int)
-    constrainMinY:          false,                                        // constrain object to an arbitrary lower Y limit (int)
-    constrainMaxY:          false,                                        // constrain object to an arbitrary upper Y limit (int)
     removeMargins:          true,                                         // remove margins for better object placement
     axis:                   null,                                         // constrain object to either 'x' or 'y' axis
     forceNonCSS3Movement:   false,                                        // DO NOT USE: this is subject to come/go. Use at your own risk
@@ -83,12 +79,10 @@
 
     this.stopEvents   = [ this.stopTrigger, this.options.stopEvents ].join(' ');
 
-    if ( this.options.constrainTo ) {
-      if ( this.options.constrainTo === 'parent' ) {
-        this.$container = this.$el.parent();
-      } else if ( this.options.constrainTo === 'document' ) {
-        this.$container = this.$document;
-      }
+    if ( this.options.constrainTo === 'parent' ) {
+      this.$container = this.$el.parent();
+    } else if ( this.options.constrainTo === 'window' ) {
+      this.$container = this.$document;
     }
 
     this.CSSEaseHash    = this.getCSSEaseHash();
@@ -623,22 +617,22 @@
     // log our positions
     this.log({ type: "pos-coords", x: this.pos.x, y: this.pos.y});
 
-    if ( this.options.constrainTo === 'custom' ) {
+    if ( typeof this.options.constrainTo === 'object' ) {
 
-      if ( this.options.constrainMinX !== false && this.options.constrainMaxX !== false ) { 
-        upperXLimit     = this.options.constrainMaxX;
-        lowerXLimit     = this.options.constrainMinX;
+      if ( this.options.constrainTo[3] !== undefined && this.options.constrainTo[1] !== undefined ) { 
+        upperXLimit     = this.options.constrainTo[1];
+        lowerXLimit     = this.options.constrainTo[3];
       }
-      if ( this.options.constrainMinY !== false && this.options.constrainMaxY !== false ) { 
-        upperYLimit       = this.options.constrainMaxY;
-        lowerYLimit       = this.options.constrainMinY;
+      if ( this.options.constrainTo[0] !== false && this.options.constrainTo[2] !== false ) { 
+        upperYLimit       = this.options.constrainTo[2];
+        lowerYLimit       = this.options.constrainTo[0];
       }
 
       // is our object trying to move outside lower X & Y limits?
       if ( this.pos.x + dx < lowerXLimit)     hash.x = lowerXLimit; 
       if ( this.pos.y + dy < lowerYLimit)     hash.y = lowerYLimit;
 
-    } else if ( this.options.constrainTo ) {
+    } else if ( typeof this.options.constrainTo === 'string' ) {
       upperXLimit       = this.$container.width()  - this.$el.outerWidth();
       upperYLimit       = this.$container.height() - this.$el.outerHeight();
       // is our object trying to move outside lower X & Y limits?


### PR DESCRIPTION
Pep had the ability to constrain to a parent or the document which worked beautifully - they are well integrated into the easing and work as expected.

However, in the example located http://codepen.io/anon/pen/mHpnj, the sliding containment was being handled within the rest event, which meant the item being moved could temporarily move outside of its container. It was up to the rest event to finally put the slider back in place, rather than ensure it's limit as constrainTo was already doing.

This commit adds support for stating an arbitrary container, and can be seen in action here:

http://codepen.io/jameslai/pen/IEGJr
