### PR TITLE
Small code clean-up, fixed the constrainTo option

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -53,7 +53,7 @@
     droppable:                      false,
     droppableActiveClass:           'pep-dpa',
     overlapFunction:                false,
-    constrainTo:                    'parent',
+    constrainTo:                    false,
     removeMargins:                  true,
     place:                          true,
     deferPlacement:                 false,
@@ -94,7 +94,7 @@
 
     if ( this.options.constrainTo === 'window' )
       this.$container = this.$document;
-    else if ( this.options.constrainTo !== 'parent' )
+    else if ( this.options.constrainTo && (this.options.constrainTo !== 'parent') )
       this.$container = $(this.options.constrainTo);
     else
       this.$container = this.$el.parent();


### PR DESCRIPTION
Removed the unused "self" declaration inside of init prototype;
constrainTo option is now "parent" by default, also can be specified to any other element if !== "window" and !== "parent".
That way it's possible to have elements between the $container and the actual $el in the DOM tree.
