### PR TITLE
Added Property useCSSTranslation

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -423,7 +423,7 @@
             var hash      = this.handleConstraint(x, y, true);
 
             // ✪  Apply the CSS3 animation easing magic  ✪
-            if ( this.cssAnimationsSupported() && this.	useCustomCSSEase)
+            if ( this.cssAnimationsSupported() && !this.options.useCustomCSSEase)
               this.$el.css( this.getCSSEaseHash() );
 
             var xOp = ( vel.x > 0 ) ? "+=" + x : "-=" + Math.abs(x);


### PR DESCRIPTION
Sometimes is needed a custom implementation of cssEaseString, and the one implemented is not suitable for all the purposes, so if anyone wants to disable it, is possible using useCSSTranslation.
