### PR TITLE
Set jQuery object as context of `revertIf` call

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -397,7 +397,7 @@
               this.removeActiveClass();
             }
 
-            if ( this.options.revert && (this.options.revertAfter === 'stop' || !this.options.shouldEase) && ( this.options.revertIf && this.options.revertIf() ) ) {
+            if ( this.options.revert && (this.options.revertAfter === 'stop' || !this.options.shouldEase) && ( this.options.revertIf && this.options.revertIf.call(this) ) ) {
               this.revert();
             }
 
@@ -463,7 +463,7 @@
               }
 
               // revert thy self!
-              if ( self.options.revert && (self.options.revertAfter === 'ease' && self.options.shouldEase) && ( self.options.revertIf && self.options.revertIf() ) ) {
+              if ( self.options.revert && (self.options.revertAfter === 'ease' && self.options.shouldEase) && ( self.options.revertIf && self.options.revertIf.call(self) ) ) {
                 self.revert();
               }
 


### PR DESCRIPTION
This allows custom implementations of `revertIf` to reference the
current selection without relying on an externally-scoped reference.
