### PR TITLE
Initialize `activeDropRegions` property

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -111,6 +111,7 @@
     this.scale          = 1;
     this.started        = false;
     this.disabled       = false;
+    this.activeDropRegions = [];
     this.resetVelocityQueue();
 
     this.init();
@@ -844,7 +845,7 @@
   //    sets parent droppables of this.
   Pep.prototype.calculateActiveDropRegions = function() {
     var self = this;
-    this.activeDropRegions = [];
+    this.activeDropRegions.length = 0;
 
     $.each( $(this.options.droppable), function(idx, el){
       var $el = $(el);

--- a/test/jquery.pep_test.js
+++ b/test/jquery.pep_test.js
@@ -69,5 +69,13 @@
     $.pep.toggleAll()
     strictEqual($el.first().data('plugin_pep').disabled, false, 'this.disable variable should be false when toggled twice');
   });
-  
+
+  test('activeDropRegions initially declared', 2, function() {
+    var $el = $( '#qunit-fixture span' );
+    $el.pep();
+
+    ok($el.data('plugin_pep').activeDropRegions, '`activeDropRegions` property is defined');
+    equal($el.data('plugin_pep').activeDropRegions.length, 0, '`activeDropRegions` property is initialized with length 0');
+  });
+
 }(jQuery));


### PR DESCRIPTION
Ensure that the `activeDropRegions` property is defined as an array
throughout the lifetime of the plugin.
