### PR TITLE
Added additional property check to guard against simulated touch events

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -908,7 +908,7 @@
   //    returns true if we're on a non-touch device -- or --
   //    if the event is **single** touch event on a touch device
   Pep.prototype.isValidMoveEvent = function(ev){
-    return ( !this.isTouch(ev) || ( this.isTouch(ev) && ev.originalEvent.touches && ev.originalEvent.touches.length === 1 ) );
+    return ( !this.isTouch(ev) || ( this.isTouch(ev) && ev.originalEvent && ev.originalEvent.touches && ev.originalEvent.touches.length === 1 ) );
   };
 
   //  shouldUseCSSTranslation();


### PR DESCRIPTION
This PR adds an additional check to check against the `touches` property in a native touch event, which may or may not exist if the user is creating or 'triggering' an artificial event.  (The example being, when a dev wants to delegate mousedowns and mouseups to touchstart and touchend for sharing events across all platforms.)  
