### PR TITLE
change the return value of the constructor

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -115,6 +115,7 @@
     this.resetVelocityQueue();
 
     this.init();
+    return this;
   }
 
   //  init();


### PR DESCRIPTION
change the return value of the constructor so the client can have access to the object prototype
