### PR TITLE
Add bower.json manifest file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,48 @@
+{
+  "name": "pep",
+  "description": "Kinetic drag for mobile & desktop",
+  "version": "0.6.2",
+  "homepage": "https://github.com/briangonzalez/jquery.pep.js",
+  "authors": [
+    {
+      "name": "Brian Gonzalez",
+      "email": "me@briangonzalez.org",
+      "homepage": "briangonzalez.org",
+      "twitter": "@brianmgonzalez"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:briangonzalez/jquery.pep.js.git"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "jquery": "*"
+  },
+  "keywords": [
+    "drag",
+    "touch",
+    "mobile",
+    "kinetic",
+    "inertia"
+  ],
+  "devDependencies": {
+    "grunt-shell": "~0.3.0",
+    "shelljs": "~0.1.4",
+    "jquery": "~1.8.3",
+    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-qunit": "~0.4.0"
+  },
+  "main": "src/jquery.pep.js",
+  "moduleType": [
+    "globals"
+  ],
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Hi Brian,

when installing jquery.pep with rails-assets or bower, I get warnings about missing "main" and "ignore" entries.

I created a bower.json file but it's the first time I'm doing that, so a) I'm not quite sure this is actually the proper way to resolve that issue, and b) you should check the manifest file anyway (for starters, I set private to "true" to avoid any unwanted publication).

Thanks for your plugin
