### PR TITLE
Changed revert to right and bottom coordinates

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -676,7 +676,7 @@
       this.moveToUsingTransforms(-this.xTranslation(),-this.yTranslation());
     }
 
-    this.moveTo(this.initialPosition.left, this.initialPosition.top);
+    this.moveTo(this.initialPosition.right, this.initialPosition.bottom);
   };
 
   //  requestAnimationFrame();


### PR DESCRIPTION
Revert does not move back to the right coordinates. They x and y coordinates should be right and bottom, not top and left. This way the element moved snaps back to its exact original position, and not an offset position.