### PR TITLE
Changed revert coordinates only when place is true.

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -676,7 +676,9 @@
       this.moveToUsingTransforms(-this.xTranslation(),-this.yTranslation());
     }
 
-    this.moveTo(this.initialPosition.right, this.initialPosition.bottom);
+    if (this.options.place) {
+      this.moveTo(this.initialPosition.top, this.initialPosition.left);
+    }
   };
 
   //  requestAnimationFrame();


### PR DESCRIPTION
When place option is false, the MoveTo function moves the elements to an offset position. Revert now functions correctly when place is true or false.