### PR TITLE
Take into account possible CSS transforms on the element

### DIFF
--- a/src/jquery.pep.js
+++ b/src/jquery.pep.js
@@ -866,13 +866,13 @@
       upperYLimit       = this.$container.height() - (this.options.useBoundingClientRect ? this.$el[0].getBoundingClientRect().height : this.$el.outerHeight());
 
       // is our object trying to move outside lower X & Y limits?
-      if ( this.pos.x + dx < 0 )              hash.x = 0;
-      if ( this.pos.y + dy < 0 )              hash.y = 0;
+      if ( this.pos.x + dx < 0 )              hash.x = -this.xTranslation();
+      if ( this.pos.y + dy < 0 )              hash.y = -this.yTranslation();
     }
 
     // is our object trying to move outside upper X & Y limits?
-    if ( this.pos.x + dx > upperXLimit )    hash.x = upperXLimit;
-    if ( this.pos.y + dy > upperYLimit )    hash.y = upperYLimit;
+    if ( this.pos.x + dx > upperXLimit )    hash.x = upperXLimit - this.xTranslation();
+    if ( this.pos.y + dy > upperYLimit )    hash.y = upperYLimit - this.yTranslation();
 
     // Account for translation, which makes movement a little tricky.
     if ( this.shouldUseCSSTranslation() && accountForTranslation ){


### PR DESCRIPTION
In my use case I'm centering pep elements with CSS transform (-50%, -50%), and positioning them absolutely using percentages (I'm doing this outside the plugin). Adding the following changes makes sure that while the elements stay in their relative position while resizing window or parent, they also work nicely with the constraint-option. Without these changes, this doesn't work well. I'm using this option with useCSSTranslation set to false, but it seems to override nicely when set to true.