### PR TITLE
chore: remove jquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
       "url": "pep.briangonzalez.org/blob/master/LICENSE-MIT"
     }
   ],
-  "dependencies": {
-    "jquery": "*"
-  },
   "keywords": [
     "drag",
     "touch",


### PR DESCRIPTION
.. to solve `yarn add jquery.pep.js` issue on Mac complaining on `contextify` shown below.
jQuery is rather peer dependency here, and other plugins like jquery-ui often don't state jQuery as peer dep either, so let's just omit it too.

```
 artem@Artems-MacBook-Pro  ~/upwork/2015-09-01Egis/eSign   no-bower ●✚  yarn add jquery.pep.js
yarn add v1.12.3
warning package.json: No license field
[1/4] 🔍  Resolving packages...
warning jquery.pep.js > jquery@1.8.3: Versions of the jquery npm package older than 1.9.0 are patched versions that don't work in web browsers. Please upgrade to >=1.11.0.
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
[7/7] ⠁ contextify
[2/7] ⠁ node-sass
[-/7] ⠁ waiting...
[6/7] ⠁ fibers
error /Users/artem/upwork/2015-09-01Egis/eSign/node_modules/contextify: Command failed.
Exit code: 1
Command: node-gyp rebuild
Arguments:
Directory: /Users/artem/upwork/2015-09-01Egis/eSign/node_modules/contextify
Output:
gyp info it worked if it ends with ok
gyp info using node-gyp@3.6.2
gyp info using node@9.11.2 | darwin | x64
gyp info spawn /usr/local/bin/python2
gyp info spawn args [ '/Users/artem/n/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'make',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/artem/upwork/2015-09-01Egis/eSign/node_modules/contextify/build/config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/artem/n/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   '/Users/artem/.node-gyp/9.11.2/include/node/common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=/Users/artem/.node-gyp/9.11.2',
gyp info spawn args   '-Dnode_gyp_dir=/Users/artem/n/lib/node_modules/npm/node_modules/node-gyp',
gyp info spawn args   '-Dnode_lib_file=/Users/artem/.node-gyp/9.11.2/<(target_arch)/node.lib',
gyp info spawn args   '-Dmodule_root_dir=/Users/artem/upwork/2015-09-01Egis/eSign/node_modules/contextify',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  CXX(target) Release/obj.target/contextify/src/contextify.o
../src/contextify.cc:131:56: warning: 'NewInstance' is deprecated [-Wdeprecated-declarations]
        Local<Object> wrapper = Nan::New(constructor)->NewInstance();
                                                       ^
/Users/artem/.node-gyp/9.11.2/include/node/v8.h:3898:3: note: 'NewInstance' has been explicitly marked deprecated here
  V8_DEPRECATED("Use maybe version", Local<Object> NewInstance() const);
  ^
/Users/artem/.node-gyp/9.11.2/include/node/v8config.h:321:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated))
                            ^
../src/contextify.cc:150:16: error: no member named 'SetAccessCheckCallbacks' in 'v8::ObjectTemplate'
        otmpl->SetAccessCheckCallbacks(GlobalPropertyNamedAccessCheck,
        ~~~~~  ^
../src/contextify.cc:182:51: warning: 'GetRealNamedProperty' is deprecated [-Wdeprecated-declarations]
        Local<Value> rv = Nan::New(ctx->sandbox)->GetRealNamedProperty(property);
                                                  ^
/Users/artem/.node-gyp/9.11.2/include/node/v8.h:3450:3: note: 'GetRealNamedProperty' has been explicitly marked deprecated here
  V8_DEPRECATED("Use maybe version",
  ^
/Users/artem/.node-gyp/9.11.2/include/node/v8config.h:321:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated))
                            ^
../src/contextify.cc:209:38: warning: 'GetRealNamedProperty' is deprecated [-Wdeprecated-declarations]
        if (!Nan::New(ctx->sandbox)->GetRealNamedProperty(property).IsEmpty() ||
                                     ^
/Users/artem/.node-gyp/9.11.2/include/node/v8.h:3450:3: note: 'GetRealNamedProperty' has been explicitly marked deprecated here
  V8_DEPRECATED("Use maybe version",
  ^
/Users/artem/.node-gyp/9.11.2/include/node/v8config.h:321:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated))
                            ^
../src/contextify.cc:210:42: warning: 'GetRealNamedProperty' is deprecated [-Wdeprecated-declarations]
            !Nan::New(ctx->proxyGlobal)->GetRealNamedProperty(property).IsEmpty()) {
                                         ^
/Users/artem/.node-gyp/9.11.2/include/node/v8.h:3450:3: note: 'GetRealNamedProperty' has been explicitly marked deprecated here
  V8_DEPRECATED("Use maybe version",
  ^
/Users/artem/.node-gyp/9.11.2/include/node/v8config.h:321:29: note: expanded from macro 'V8_DEPRECATED'
  declarator __attribute__((deprecated))
                            ^
4 warnings and 1 error generated.
make: *** [Release/obj.target/contextify/src/contextify.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/artem/n/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:258:23)
gyp ERR! stack     at ChildProcess.emit (events.js:180:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:209:12)
gyp ERR! System Darwin 18.2.0
gyp ERR! command "/Users/artem/n/bin/node" "/Users/artem/n/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/artem/upwork/2015-09-01Egis/eSign/node_modules/contextify
```